### PR TITLE
Workflow for building wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,18 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: ${{matrix.os}}-py${{matrix.python_version}}
         path: ./wheels/*.whl
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+    - name: Merge artifacts
+      uses: actions/upload-artifact/merge@v4
+      with:
+        name: wheels
+        pattern: "*-py*"
 
   build_sdist:
     name: Build source distribution
@@ -51,4 +62,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: 'sdist.tar.gz'
           path: dist/online_monitor*.tar.gz

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,25 +5,29 @@ on: workflow_dispatch
 
 jobs:
   build_wheels:
-    name: Build wheels
-    runs-on: ubuntu-latest
+    name: Build wheels on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2025, macos-15-large]
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Setup python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.8"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install wheel
+    - uses: actions/checkout@v5
 
     - name: Build wheels
-      run: python -m pip wheel --wheel-dir=./wheels .
+      uses: pypa/cibuildwheel@v3.2.0
+      with:
+        output-dir: wheels
+      env:
+        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+        CIBW_ARCHS_LINUX: "x86_64 i686"
+        CIBW_ARCHS_WINDOWS: "AMD64"
+        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* # Build on CPython 3.9 - 3.13
+        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
+        CIBW_SKIP: "*_ppc64le *_s390x *-musllinux*"
+        CIBW_TEST_COMMAND: pytest {package}
+        CIBW_TEST_SKIP: "*-macosx_*"
       
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheels/online_monitor*.whl
 
@@ -31,12 +35,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.13"
         
       - name: Install build module
         run: python -m pip install build
@@ -44,6 +48,6 @@ jobs:
       - name: Build sdist
         run: python -m build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/online_monitor*.tar.gz

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubunu-22-04, ubuntu-24.04]  # , windows-2025, macos-15]
+        os: [ubunu-22.04, ubuntu-24.04]  # , windows-2025, macos-15]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v5
@@ -30,7 +30,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: ${{matrix.os}}-py${{matrix.python_version}}
+        name: ${{matrix.os}}-py${{matrix.python_version}}.whl
         path: ./wheels/*.whl
 
   merge:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubunu-20-04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15]
+        os: [ubunu-22-04, ubuntu-24.04, windows-2025, macos-15]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Build wheels
       run:
-        python -m pip wheel --whell-dir=./wheels .
+        python -m pip wheel --wheel-dir=./wheels .
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubunu-22-04, ubuntu-24.04, windows-2025, macos-15]
+        os: [ubunu-22-04, ubuntu-24.04]  # , windows-2025, macos-15]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15-large]
+        os: [ubuntu-24.04, windows-2025, macos-15]
     steps:
     - uses: actions/checkout@v5
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubunu-22.04, ubuntu-24.04]  # , windows-2025, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2025] #, macos-15]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,28 +5,29 @@ on: workflow_dispatch
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{matrix.os}}
+    name: Build wheels on ${{matrix.os}} for Python ${{matrix.python_version}}
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubunu-20-04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v5
 
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v3.2.0
+    - name: Setup Python
+      uses: actions/setup-python@v6
       with:
-        output-dir: wheels
-      env:
-        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-        CIBW_ARCHS_LINUX: "x86_64 i686"
-        CIBW_ARCHS_WINDOWS: "AMD64"
-        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* # Build on CPython 3.9 - 3.13
-        CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
-        CIBW_SKIP: "*_ppc64le *_s390x *-musllinux*"
-        CIBW_TEST_COMMAND: pytest {package}
-        CIBW_TEST_SKIP: "*-macosx_*"
-      
+        python-version: ${{matrix.python_version}}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel
+
+    - name: Build wheels
+      run:
+        python -m pip wheel --whell-dir=./wheels .
+
     - uses: actions/upload-artifact@v4
       with:
         path: ./wheels/online_monitor*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        path: ./wheels/online_monitor*.whl
+        path: ./wheels/*.whl
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2025] #, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2025, macos-15, macos-26]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
This PR updates the workflow to build wheels for multiple OSes and Python versions to upload to pipy (for a new release 0.7)