### PR TITLE
Allow coverage report upload to fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,8 @@ jobs:
         with:
           qt: true
 
-      - name: Coverage report and upload  
+      - name: Coverage report and upload
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Uploading the coverage report to a third-party-service should not let the pipeline fail (as currently due to a two-day-outage)